### PR TITLE
Update ContentTransferEncoding.java

### DIFF
--- a/modules/core-module/src/main/java/org/simplejavamail/api/email/ContentTransferEncoding.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/api/email/ContentTransferEncoding.java
@@ -32,7 +32,7 @@ public enum ContentTransferEncoding {
 
 	public static ContentTransferEncoding byEncoder(@NotNull final String encoder) {
 		return Arrays.stream(values())
-				.filter(c -> c.encoder.equals(encoder))
+				.filter(c -> c.encoder.equalsIgnoreCase(encoder))
 				.findFirst()
 				.orElseThrow(() -> new IllegalArgumentException("unknown content transfer encoder: " + encoder));
 	}


### PR DESCRIPTION
found em files in the wild with "BASE64" (uppercase!) encoding attribs, so seems ok to compare equality and ignoring the case...